### PR TITLE
Simplify build/launch docker image/container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ ARG GROUP_ID
 ENV USER='test'
 ENV DEF_USER_ID=1000
 ENV DEF_GROUP_ID=1000
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get -qq update; apt-get -y install nodejs gettext libgettextpo-dev libgraphviz-dev libz-dev libjpeg-dev libfreetype6-dev python3-dev gdal-bin python-numpy locales locales-all
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
 RUN npm install -g less bower
 RUN pip3 install pipenv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG GROUP_ID
 ENV USER='test'
 ENV DEF_USER_ID=1000
 ENV DEF_GROUP_ID=1000
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get -qq update; apt-get -y install nodejs gettext libgettextpo-dev libgraphviz-dev libz-dev libjpeg-dev libfreetype6-dev python3-dev gdal-bin python-numpy locales locales-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,44 @@
 FROM python:3.6
+
+ARG USER_ID
+ARG GROUP_ID
+ENV USER='test'
+ENV DEF_USER_ID=1000
+ENV DEF_GROUP_ID=1000
+
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get -qq update; apt-get -y install nodejs gettext libgettextpo-dev libgraphviz-dev libz-dev libjpeg-dev libfreetype6-dev python3-dev gdal-bin python-numpy locales locales-all
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
 RUN npm install -g less bower
 RUN pip3 install pipenv
-RUN useradd test
-RUN chsh test -s /bin/bash
-RUN mkdir /home/test ; chown test /home/test ; chgrp test /home/test
-WORKDIR "/home/test"
-copy Pipfile.lock Pipfile.lock
-copy Pipfile Pipfile
-RUN su test -c 'cd /home/test ; pipenv install --python python3'
-copy . .
-copy ./docker/build-env ./.env
-RUN chown -R test /home/test ; chgrp -R test /home/test
-run mkdir -p /var/log/django
-run chown -R test /var/log/django
-user test
-run cd /home/test ; npm install
-run cd /home/test ; npm install bower less jshint
-run cd /home/test ; npm install uglify-js@2.8.21
-run cd /home/test ; pipenv run python3 manage.py bower install
-run cd /home/test ; pipenv run python3 manage.py collectstatic --noinput
-run cd /home/test ; pipenv run python manage.py collectmedia --noinput
-run cd bower_components/ol2/build/ && pipenv run python build.py -c none ../../../apps/cyklomapa/static/openstreetmap-pnk ../../../apps/cyklomapa/static/js/OpenLayers.PNK.js
-run cd /home/test ; pipenv run python3 manage.py compress
+
+RUN if getent group ${USER}; then groupdel "${USER}"; fi && \
+    groupadd --gid "${GROUP_ID:-${DEF_GROUP_ID}}" "${USER}" && \
+    if getent passwd ${USER}; then userdel -f ${USER}; fi && \
+    useradd \
+      --uid ${USER_ID:-${DEF_USER_ID}} \
+      --gid ${GROUP_ID:-${DEF_GROUP_ID}} \
+      --create-home \
+      --shell /bin/bash \
+      ${USER}
+
+WORKDIR "/app-v"
+RUN chown -R ${USER_ID:-${DEF_USER_ID}}:${GROUP_ID:-${DEF_GROUP_ID}} /app-v
+USER ${USER}
+COPY --chown=${USER_ID:-${DEF_USER_ID}}:${GROUP_ID:-${DEF_GROUP_ID}} Pipfile.lock Pipfile.lock
+COPY --chown=${USER_ID:-${DEF_USER_ID}}:${GROUP_ID:-${DEF_GROUP_ID}} Pipfile Pipfile
+RUN pipenv install --dev --python python3
+COPY --chown=${USER_ID:-${DEF_USER_ID}}:${GROUP_ID:-${DEF_GROUP_ID}} . .
+COPY --chown=${USER_ID:-${DEF_USER_ID}}:${GROUP_ID:-${DEF_GROUP_ID}} ./docker/build-env ./.env
+
+USER root
+RUN rm -rf /app-v
+RUN mkdir -p /var/log/django
+RUN chown -R ${USER} /var/log/django
+
+WORKDIR "/home/${USER}"
+USER ${USER}
+RUN npm install
+RUN npm install bower less jshint
+RUN npm install uglify-js@2.8.21
+
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ Installation (Docker compose)
     # default container user 'test' ID=1000, GID=1000
     $ docker-compose build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER})
     $ docker-compose up
-    $ docker exec -it --user test prahounakole_web_1 sh -c "/app-v/post_build.sh && pipenv run python manage.py migrate"
+    $ docker exec -it --user test prahounakole_web_1 sh -c "/app-v/post_build.sh"
 
     Check prahounakole web app on the host web browser with URL http://localhost:8033/

--- a/README.md
+++ b/README.md
@@ -55,3 +55,15 @@ Pro testovací účely spustíte projekt pomocí následujícího příkazu:
 ```
 env/bin/python manage.py runserver 0.0.0.0:8000
 ```
+
+Installation (Docker compose)
+==========================
+
+    $ docker-compose build
+    # Or if you want map container user with host user via (ID, GID),
+    # default container user 'test' ID=1000, GID=1000
+    $ docker-compose build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER})
+    $ docker-compose up
+    $ docker exec -it --user test prahounakole_web_1 sh -c "/app-v/post_build.sh && pipenv run python manage.py migrate"
+
+    Check prahounakole web app on the host web browser with URL http://localhost:8033/

--- a/apps/cyklomapa/middleware/subdomains_middleware.py
+++ b/apps/cyklomapa/middleware/subdomains_middleware.py
@@ -1,7 +1,10 @@
-from cyklomapa.models import Mesto
+import os
 
 import django
+
 from django.conf import settings
+
+from ..models import Mesto
 
 
 class SubdomainsMiddleware:
@@ -21,7 +24,11 @@ class SubdomainsMiddleware:
         # umoznime nastavit subdomenu pomoci settings
         request.subdomain = getattr(settings, 'FORCE_SUBDOMAIN', request.subdomain)
 
+        if (os.getenv('DJANGO_SETTINGS_MODULE') in settings.DEV_SETTINGS):
+            request.subdomain = 'testing-sector'
+
         # najdeme mesto podle slugu. pokud neexistuje, vyhodime 404
+
         try:
             request.mesto = Mesto.objects.get(sektor__slug=request.subdomain)
         except Mesto.DoesNotExist:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,8 @@ services:
   env_file: .env
   #entrypoint: bash
   volumes:
-   - ./:/app-v/
-   - ./pipenv:/home/test
+  - ./:/app-v/
+  # - ./pipenv:/home/test
  postgres:
   image: mdillon/postgis:9.6-alpine
   volumes:

--- a/post_build.sh
+++ b/post_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+pipenv run python manage.py bower install
+pipenv run python manage.py collectstatic --noinput
+pipenv run python manage.py collectmedia --noinput
+cd bower_components/ol2/build/ && pipenv run python build.py -c none ../../../apps/cyklomapa/static/openstreetmap-pnk ../../../apps/cyklomapa/static/js/OpenLayers.PNK.js
+cd /app-v
+pipenv run python manage.py compress --force

--- a/post_build.sh
+++ b/post_build.sh
@@ -6,3 +6,5 @@ pipenv run python manage.py collectmedia --noinput
 cd bower_components/ol2/build/ && pipenv run python build.py -c none ../../../apps/cyklomapa/static/openstreetmap-pnk ../../../apps/cyklomapa/static/js/OpenLayers.PNK.js
 cd /app-v
 pipenv run python manage.py compress --force
+pipenv run python manage.py migrate
+pipenv run python manage.py loaddata apps/cyklomapa/fixtures/*

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -386,3 +386,5 @@ if AWS_ACCESS_KEY_ID:
 
 
 CYCLESTREETS_API_KEY = os.environ.get('CYCLESTREETS_API_KEY', 'csapi-key-not-set')
+
+DEV_SETTINGS = ('project.settings.dockerdev', 'project.settings.dev')

--- a/project/settings/dockerdev.py
+++ b/project/settings/dockerdev.py
@@ -1,3 +1,3 @@
 from settings.dev import *  # noqa
 
-DEBUG=True
+DEBUG = True


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. `cd /tmp && git clone https://github.com/auto-mat/prahounakole.git && cd prahounakole/`
2. `docker-compose build`
3. `docker-compose up`
4. See error message

**Error message**

```
web_1       | Traceback (most recent call last):
web_1       |   File "/usr/local/bin/pipenv", line 10, in <module>
web_1       |     sys.exit(cli())
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 829, in __call__
web_1       |     return self.main(*args, **kwargs)
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 782, in main
web_1       |     rv = self.invoke(ctx)
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 1259, in invoke
web_1       |     return _process_result(sub_ctx.command.invoke(sub_ctx))
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 1066, in invoke
web_1       |     return ctx.invoke(self.callback, **ctx.params)
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 610, in invoke
web_1       |     return callback(*args, **kwargs)
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/decorators.py", line 73, in new_func
web_1       |     return ctx.invoke(f, obj, *args, **kwargs)
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 610, in invoke
web_1       |     return callback(*args, **kwargs)
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/cli/command.py", line 450, in run
web_1       |     command=command, args=args, three=state.three, python=state.python, pypi_mirror=state.pypi_mirror
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/core.py", line 2513, in do_run
web_1       |     three=three, python=python, validate=False, pypi_mirror=pypi_mirror,
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/core.py", line 580, in ensure_project
web_1       |     pypi_mirror=pypi_mirror,
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/core.py", line 493, in ensure_virtualenv
web_1       |     if not project.virtualenv_exists:
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/project.py", line 271, in virtualenv_exists
web_1       |     if os.path.exists(self.virtualenv_location):
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/project.py", line 470, in virtualenv_location
web_1       |     self._virtualenv_location = self.get_location_for_virtualenv()
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/project.py", line 294, in get_location_for_virtualenv
web_1       |     return str(get_workon_home().joinpath(self.virtualenv_name))
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/utils.py", line 2014, in get_workon_home
web_1       |     mkdir_p(str(expanded_path))
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/utils.py", line 1486, in mkdir_p
web_1       |     mkdir_p(head)
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/utils.py", line 1486, in mkdir_p
web_1       |     mkdir_p(head)
web_1       |   File "/usr/local/lib/python3.6/site-packages/pipenv/utils.py", line 1491, in mkdir_p
web_1       |     os.mkdir(newdir)
web_1       | PermissionError: [Errno 13] Permission denied: '/home/test/.local'
web_1       | postgres_1  | CREATE DATABASE
```

**Additional info**

Container user is mapped to host user via ID and GID (same). Bug related with this line code: https://github.com/auto-mat/prahounakole/blob/c9348156b4dda2ddee44586b8284b6ab88a95776/docker-compose.yaml#L22 After container launch 'pipenv' dir is created in the host 'prahonakole' app dir with root permission.

If I manually change permission for this dir from root to my host user and try launch 'prahounakole_web_1' container again (`docker-compose up`) I get another error message:

```
web_1       | Creating a virtualenv for this project...
web_1       | Pipfile: /app-v/Pipfile
web_1       | Using /usr/local/bin/python3.6m (3.6.8) to create virtualenv...
⠙ Creating virtual environment...created virtual environment CPython3.6.8.final.0-64 in 511ms
web_1       |   creator CPython3Posix(dest=/home/test/.local/share/virtualenvs/app-v-QaxYZVWa, clear=False, no_vcs_ignore=False, global=False)
web_1       |   seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/test/.local/share/virtualenv)
web_1       |     added seed packages: pip==21.0.1, setuptools==52.0.0, wheel==0.36.2
web_1       |   activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator,XonshActivator
web_1       | 
✔ Successfully created virtual environment! 
web_1       | Virtualenv location: /home/test/.local/share/virtualenvs/app-v-QaxYZVWa
web_1       | Loading .env environment variables...
web_1       | Error: the command gunicorn could not be found within PATH or Pipfile's [scripts].
web_1       | prahounakole_web_1 exited with code 1
```` 

This is because the Dockerfile `WORKDIR` directive points to "/home/test", where pipenv points too (but mapped `prahounakole` app dir is `/app-v`):
https://github.com/auto-mat/prahounakole/blob/c9348156b4dda2ddee44586b8284b6ab88a95776/Dockerfile#L12 

**Expected behavior**

Launch  'prahounakole_web_1' container without errors, and additional steps/rebuilding.