### PR TITLE
project/settings: enable reading / writing MEDIA files to AWS S3 Bucket storage

### DIFF
--- a/apps/cyklomapa/storage_backends.py
+++ b/apps/cyklomapa/storage_backends.py
@@ -1,0 +1,6 @@
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class AwsS3MediaStorage(S3Boto3Storage):
+    default_acl = 'public-read'
+    file_overwrite = False

--- a/apps/cyklomapa/templates/gis/popup.html
+++ b/apps/cyklomapa/templates/gis/popup.html
@@ -1,4 +1,4 @@
-{% load thumbnail static %}
+{% load thumbnail static filters %}
 {% load comments %}
 <div>
 <div class="trc" id="poi_id_{{ poi.id }}">
@@ -27,10 +27,12 @@
 <div class="rc txt">
 {% if fotky %}
   {% for fotka in fotky %}
-    {% thumbnail fotka.photo "300x0" as foto_thumb %}
-    {{ fotka }}
-    <a href="{{ fotka.photo.url }}" title="{{ fotka }}" data-lightbox="poi-image" data-title="{{ fotka }}">
-    <img src="{{ foto_thumb.url }}" title="{{ fotka }}" width="{{ foto_thumb.width }}" height="{{ foto_thumb.height }}" class="foto_thumb"/></a>
+    {% with fotka.photo.url|get_file_path as photo %}
+      {% thumbnail photo "300x0" as foto_thumb %}
+        {{ fotka }}
+        <a href="{{ fotka.photo.url }}" title="{{ fotka }}" data-lightbox="poi-image" data-title="{{ fotka }}">
+        <img src="{{ foto_thumb.url }}" title="{{ fotka }}" width="{{ foto_thumb.width }}" height="{{ foto_thumb.height }}" class="foto_thumb"/></a>
+    {% endwith %}
   {% endfor %}
 {% endif %}
 

--- a/apps/cyklomapa/templatetags/filters.py
+++ b/apps/cyklomapa/templatetags/filters.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+from django import template
+
+register = template.Library()
+
+
+@register.filter(name='get_file_path')
+def get_file_path(value):
+    """Get AWS S3 file path"""
+    return value.split(settings.MEDIA_URL)[-1]

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -370,16 +370,20 @@ FEEDBACK_CAPTCHAS = [
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_S3_REGION_NAME = os.environ.get('AWS_S3_REGION_NAME', 'eu-west-1')
-AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', 'cyklomapa-media')
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', 'cyklomapa-test-media')
 AWS_QUERYSTRING_AUTH = os.environ.get('AWS_QUERYSTRING_AUTH', True)
 AWS_QUERYSTRING_EXPIRE = os.environ.get('AWS_QUERYSTRING_EXPIRE', 60 * 60 * 24 * 365 * 10)
-AWS_DEFAULT_ACL = "private"
+AWS_DEFAULT_ACL = None
 
 
 if AWS_ACCESS_KEY_ID:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-    THUMBNAIL_DEFAULT_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-    AWS_SES_REGION_NAME = 'eu-west-1'
+    AWS_SES_REGION_NAME = os.environ.get('AWS_SES_REGION_NAME', 'eu-west-1')
+    AWS_S3_CUSTOM_DOMAIN = f'{AWS_STORAGE_BUCKET_NAME}.s3-{AWS_SES_REGION_NAME}.amazonaws.com'
+    MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/"
+    DEFAULT_FILE_STORAGE = 'cyklomapa.storage_backends.AwsS3MediaStorage'
+    THUMBNAIL_DEFAULT_STORAGE = 'cyklomapa.storage_backends.AwsS3MediaStorage'
+    THUMBNAIL_SUBDIR = 'thumbs'
+
     AWS_SES_REGION_ENDPOINT = 'email.eu-west-1.amazonaws.com'
     EMAIL_BACKEND = 'django_ses.SESBackend'
     MEDIA_ROOT = ""

--- a/project/settings/dev.py
+++ b/project/settings/dev.py
@@ -1,11 +1,14 @@
+import os
+
 from settings import *  # noqa
-from settings import ALLOWED_HOSTS, INSTALLED_APPS, LOGGING, MIDDLEWARE, TEMPLATES
+from settings import (
+    AWS_ACCESS_KEY_ID, ALLOWED_HOSTS, INSTALLED_APPS, LOGGING,
+    MIDDLEWARE, TEMPLATES,
+)
 
 INSTALLED_APPS += (
     'debug_toolbar',
 )
-
-MEDIA_URL = '/media/'
 
 MIDDLEWARE += (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
@@ -49,3 +52,8 @@ class InvalidStringError(str):
 
 
 TEMPLATES[0]['OPTIONS']['string_if_invalid'] = InvalidStringError("%s")
+
+if AWS_ACCESS_KEY_ID:
+    THUMBNAIL_DEBUG = True
+else:
+    MEDIA_URL = '/media/'


### PR DESCRIPTION
For correct loading of 'Poi' model photos to webmap / panel. Tested on 'cyklomapa-test-media' and 'cyklomapa-media' AWS S3 Bucket storage.

![load_poi_photo_from_aws_s3_bucket_storage](https://user-images.githubusercontent.com/50632337/108355914-b7cf4700-71eb-11eb-8d4d-9a68539f0136.jpeg)
