### PR TITLE
api/views: fix raw query IN operator values param

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -34,12 +34,9 @@ class PoiViewSet(viewsets.ReadOnlyModelViewSet):
             FROM cyklomapa_czechiaregions INNER JOIN webmap_poi ON ST_Intersects(
                 cyklomapa_czechiaregions.geom,
                 webmap_poi.geom
-            ) WHERE webmap_poi.id IN (%s)
-            """, [', '.join([str(i) for i in self.queryset.values_list(
-                'id', flat=True)]),
-            ],
+            ) WHERE webmap_poi.id IN %s
+            """, [tuple(self.queryset.values_list('id', flat=True))]
         )
-
 
 
 router = routers.DefaultRouter()


### PR DESCRIPTION
Fix raw query IN operator values param.

**Error message**

```
DataError: invalid input syntax for type integer: "5999, 3905, 4338, 4339, 3906, 5213, 6714, 7025, 7026, 7102, 7119"
LINE 7:             ) WHERE webmap_poi.id IN ('5999, 3905, 4338, 433...
```